### PR TITLE
feat: create Figma groups from Theme UI nested styles

### DIFF
--- a/src/core/__tests__/colors.ts
+++ b/src/core/__tests__/colors.ts
@@ -93,7 +93,7 @@ describe(`parseColors`, () => {
         },
       },
       {
-        name: `brand.primary`,
+        name: `brand / primary`,
         value: {
           a: 1,
           b: 0.6,
@@ -102,7 +102,7 @@ describe(`parseColors`, () => {
         },
       },
       {
-        name: `brand.secondary`,
+        name: `brand / secondary`,
         value: {
           a: 1,
           b: 0,

--- a/src/core/__tests__/colors.ts
+++ b/src/core/__tests__/colors.ts
@@ -93,7 +93,7 @@ describe(`parseColors`, () => {
         },
       },
       {
-        name: `brand / primary`,
+        name: `brand/primary`,
         value: {
           a: 1,
           b: 0.6,
@@ -102,7 +102,7 @@ describe(`parseColors`, () => {
         },
       },
       {
-        name: `brand / secondary`,
+        name: `brand/secondary`,
         value: {
           a: 1,
           b: 0,

--- a/src/core/__tests__/utils.ts
+++ b/src/core/__tests__/utils.ts
@@ -38,14 +38,14 @@ describe(`flattenObject`, () => {
       harry: `potter`,
     })
   })
-  test(`should flatten one level`, () => {
+  test(`should group things in one level`, () => {
     expect(flattenObject(oneLevel)).toStrictEqual({
       foo: `bar`,
       "gryffindor / harry": `potter`,
       "gryffindor / hermione": `granger`,
     })
   })
-  test(`should flatten more than one level`, () => {
+  test(`should make groups for more than one level`, () => {
     expect(flattenObject(twoLevel)).toStrictEqual({
       foo: `bar`,
       "hogwarts / gryffindor / harry": `potter`,

--- a/src/core/__tests__/utils.ts
+++ b/src/core/__tests__/utils.ts
@@ -41,21 +41,21 @@ describe(`flattenObject`, () => {
   test(`should group things in one level`, () => {
     expect(flattenObject(oneLevel)).toStrictEqual({
       foo: `bar`,
-      "gryffindor / harry": `potter`,
-      "gryffindor / hermione": `granger`,
+      "gryffindor/harry": `potter`,
+      "gryffindor/hermione": `granger`,
     })
   })
   test(`should make groups for more than one level`, () => {
     expect(flattenObject(twoLevel)).toStrictEqual({
       foo: `bar`,
-      "hogwarts / gryffindor / harry": `potter`,
-      "hogwarts / slytherin / draco": `malfoy`,
+      "hogwarts/gryffindor/harry": `potter`,
+      "hogwarts/slytherin/draco": `malfoy`,
     })
   })
   test(`should skip null/undefined`, () => {
     expect(flattenObject(withNull)).toStrictEqual({
-      "indigo / 1": `#ebf4ff`,
-      "indigo / 2": `#c3dafe`,
+      "indigo/1": `#ebf4ff`,
+      "indigo/2": `#c3dafe`,
     })
   })
 })

--- a/src/core/__tests__/utils.ts
+++ b/src/core/__tests__/utils.ts
@@ -41,21 +41,21 @@ describe(`flattenObject`, () => {
   test(`should flatten one level`, () => {
     expect(flattenObject(oneLevel)).toStrictEqual({
       foo: `bar`,
-      "gryffindor.harry": `potter`,
-      "gryffindor.hermione": `granger`,
+      "gryffindor / harry": `potter`,
+      "gryffindor / hermione": `granger`,
     })
   })
   test(`should flatten more than one level`, () => {
     expect(flattenObject(twoLevel)).toStrictEqual({
       foo: `bar`,
-      "hogwarts.gryffindor.harry": `potter`,
-      "hogwarts.slytherin.draco": `malfoy`,
+      "hogwarts / gryffindor / harry": `potter`,
+      "hogwarts / slytherin / draco": `malfoy`,
     })
   })
   test(`should skip null/undefined`, () => {
     expect(flattenObject(withNull)).toStrictEqual({
-      "indigo.1": `#ebf4ff`,
-      "indigo.2": `#c3dafe`,
+      "indigo / 1": `#ebf4ff`,
+      "indigo / 2": `#c3dafe`,
     })
   })
 })

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -5,7 +5,7 @@ export const flattenObject = (object) => {
       const value = obj[key]
       if (!value) return false
       if (typeof value === `object`) {
-        flatten(value, `${prefix}${key} / `)
+        flatten(value, `${prefix}${key}/`)
       } else {
         result[`${prefix}${key}`] = value
       }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -5,7 +5,7 @@ export const flattenObject = (object) => {
       const value = obj[key]
       if (!value) return false
       if (typeof value === `object`) {
-        flatten(value, `${prefix}${key}.`)
+        flatten(value, `${prefix}${key} / `)
       } else {
         result[`${prefix}${key}`] = value
       }


### PR DESCRIPTION
Currently, when you import a theme, you get a flat list of colors:
![image](https://user-images.githubusercontent.com/10226086/84190222-7034d080-aa4b-11ea-939f-2d14a9d6a231.png)

In Figma, you can use a `/` to create groups of styles, like so:
![image](https://user-images.githubusercontent.com/10226086/84190153-4ed3e480-aa4b-11ea-8639-90632d54119d.png)

